### PR TITLE
Add workout JSON import and local storage persistence

### DIFF
--- a/src/screens/ListScreen.tsx
+++ b/src/screens/ListScreen.tsx
@@ -1,36 +1,158 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { useStore } from "../store";
 import DifficultyDots from "../components/DifficultyDots";
+import { parseWorkoutJson } from "../utils/workoutValidation";
 
 const ListScreen: React.FC = () => {
-  const { workouts, selectWorkout } = useStore();
+  const workouts = useStore((state) => state.workouts);
+  const selectWorkout = useStore((state) => state.selectWorkout);
+  const addWorkout = useStore((state) => state.addWorkout);
+  const removeWorkout = useStore((state) => state.removeWorkout);
+  const [showForm, setShowForm] = useState(false);
+  const [jsonInput, setJsonInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const workoutCountLabel = useMemo(() => {
+    if (workouts.length === 0) return "No hay workouts guardados";
+    if (workouts.length === 1) return "1 workout guardado";
+    return `${workouts.length} workouts guardados`;
+  }, [workouts.length]);
+
+  const handleToggleForm = () => {
+    setShowForm((prev) => {
+      const next = !prev;
+      if (!next) {
+        setJsonInput("");
+        setError(null);
+      }
+      return next;
+    });
+  };
+
+  const handleAddWorkout = () => {
+    const text = jsonInput.trim();
+    if (!text) {
+      setError("Introduce un JSON para añadir un workout.");
+      return;
+    }
+
+    const result = parseWorkoutJson(text);
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    if (workouts.some((w) => w.id === result.workout.id)) {
+      setError(`Ya existe un workout con el id "${result.workout.id}".`);
+      return;
+    }
+
+    addWorkout(result.workout);
+    setJsonInput("");
+    setError(null);
+    setShowForm(false);
+  };
+
+  const handleRemoveWorkout = (id: string, name: string) => {
+    if (typeof window !== "undefined") {
+      const confirmation = window.confirm(
+        `¿Seguro que quieres eliminar "${name}"? Esta acción no se puede deshacer.`,
+      );
+      if (!confirmation) return;
+    }
+    removeWorkout(id);
+  };
 
   return (
     <div className="max-w-md mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">🏋️ Workout</h1>
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h1 className="text-2xl font-bold">🏋️ Workout</h1>
+        <button
+          type="button"
+          onClick={handleToggleForm}
+          className="rounded-lg border border-gray-200 px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 active:bg-gray-100"
+        >
+          {showForm ? "Cerrar" : "Añadir"}
+        </button>
+      </div>
+      <p className="text-sm text-gray-600 mb-2">{workoutCountLabel}</p>
       <p className="text-sm text-gray-600 mb-4">
         Elige un <strong>workout</strong> para comenzar. Al pulsar verás un
         countdown de 5s con pitidos. En el último segundo, sonará un pitido
         largo de inicio.
       </p>
+      {showForm && (
+        <div className="mb-6 rounded-xl border border-gray-200 bg-gray-50 p-4">
+          <h2 className="text-base font-semibold mb-2">Añadir workout</h2>
+          <p className="text-xs text-gray-500 mb-2">
+            Pega un JSON con la estructura del workout. Debe cumplir la interfaz
+            indicada en la descripción.
+          </p>
+          <textarea
+            value={jsonInput}
+            onChange={(e) => {
+              setJsonInput(e.target.value);
+              if (error) setError(null);
+            }}
+            className="h-40 w-full rounded-lg border border-gray-200 bg-white p-2 text-sm font-mono outline-none focus:ring-2 focus:ring-gray-300"
+            placeholder='{"id":"id-unico","name":"Nombre","dificultyLevel":3,"exercises":[{"name":"Ejercicio","description":"Descripción"}]}'
+          />
+          {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+          <div className="mt-4 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleAddWorkout}
+              className="rounded-lg bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-800 active:bg-gray-700"
+            >
+              Guardar workout
+            </button>
+            <button
+              type="button"
+              onClick={handleToggleForm}
+              className="rounded-lg px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100"
+            >
+              Cancelar
+            </button>
+          </div>
+        </div>
+      )}
+      {workouts.length === 0 && (
+        <p className="text-sm text-gray-500">
+          Añade tu primer workout usando el botón «Añadir».
+        </p>
+      )}
       <div className="space-y-3">
         {workouts.map((w) => (
-          <button
+          <div
             key={w.id}
-            onClick={() => selectWorkout(w.id)}
-            className="w-full rounded-xl border border-gray-200 p-4 text-left hover:bg-gray-50 active:bg-gray-100 transition"
+            className="w-full rounded-xl border border-gray-200 p-4 hover:bg-gray-50"
           >
-            <div className="flex items-center justify-between">
-              <div className="font-semibold">{w.name}</div>
-              <DifficultyDots level={w.dificultyLevel} />
+            <div className="flex items-start justify-between gap-3">
+              <button
+                type="button"
+                onClick={() => selectWorkout(w.id)}
+                className="flex-1 text-left"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="font-semibold">{w.name}</div>
+                  <DifficultyDots level={w.dificultyLevel} />
+                </div>
+                <div className="mt-2 text-xs text-gray-500">
+                  {w.exercises.length} ejercicios •{" "}
+                  {w.exercises.some((e) => e.workingSeconds)
+                    ? "Con tiempo"
+                    : "Sólo repeticiones"}
+                </div>
+              </button>
+              <button
+                type="button"
+                onClick={() => handleRemoveWorkout(w.id, w.name)}
+                className="rounded-lg border border-red-200 px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50"
+              >
+                Eliminar
+              </button>
             </div>
-            <div className="mt-2 text-xs text-gray-500">
-              {w.exercises.length} ejercicios •{" "}
-              {w.exercises.some((e) => e.workingSeconds)
-                ? "Con tiempo"
-                : "Sólo repeticiones"}
-            </div>
-          </button>
+          </div>
         ))}
       </div>
     </div>

--- a/src/utils/workoutValidation.ts
+++ b/src/utils/workoutValidation.ts
@@ -1,0 +1,151 @@
+import { Exercise, Workout } from "../types";
+
+export type WorkoutValidationResult =
+  | { ok: true; workout: Workout }
+  | { ok: false; error: string };
+
+type ExerciseValidationResult =
+  | { ok: true; workout: Exercise }
+  | { ok: false; error: string };
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
+const isPositiveInteger = (value: unknown): value is number =>
+  typeof value === "number" && Number.isInteger(value) && value > 0;
+
+const isNonNegativeInteger = (value: unknown): value is number =>
+  typeof value === "number" && Number.isInteger(value) && value >= 0;
+
+const allowedLevels = new Set([1, 2, 3, 4, 5]);
+
+const sanitizeExercise = (
+  input: unknown,
+  index: number,
+): ExerciseValidationResult => {
+  if (typeof input !== "object" || input === null) {
+    return { ok: false, error: `El ejercicio #${index + 1} debe ser un objeto.` };
+  }
+
+  const record = input as Record<string, unknown>;
+  const { name, description, mediaUrl, workingSeconds, restingSeconds, repetitionsCount } = record;
+
+  if (!isNonEmptyString(name)) {
+    return {
+      ok: false,
+      error: `El ejercicio #${index + 1} debe tener un "name" de tipo string no vacío.`,
+    };
+  }
+
+  if (!isNonEmptyString(description)) {
+    return {
+      ok: false,
+      error: `El ejercicio #${index + 1} debe tener una "description" de tipo string no vacía.`,
+    };
+  }
+
+  const exercise: Exercise = {
+    name: name.trim(),
+    description: description.trim(),
+  };
+
+  if (mediaUrl !== undefined) {
+    if (!isNonEmptyString(mediaUrl)) {
+      return {
+        ok: false,
+        error: `El ejercicio #${index + 1} tiene un "mediaUrl" inválido. Debe ser un string.`,
+      };
+    }
+    exercise.mediaUrl = mediaUrl.trim();
+  }
+
+  if (workingSeconds !== undefined) {
+    if (!isPositiveInteger(workingSeconds)) {
+      return {
+        ok: false,
+        error: `El ejercicio #${index + 1} tiene "workingSeconds" inválido. Debe ser un número entero positivo.`,
+      };
+    }
+    exercise.workingSeconds = workingSeconds;
+  }
+
+  if (restingSeconds !== undefined) {
+    if (!isNonNegativeInteger(restingSeconds)) {
+      return {
+        ok: false,
+        error: `El ejercicio #${index + 1} tiene "restingSeconds" inválido. Debe ser un número entero mayor o igual que 0.`,
+      };
+    }
+    exercise.restingSeconds = restingSeconds;
+  }
+
+  if (repetitionsCount !== undefined) {
+    if (!isPositiveInteger(repetitionsCount)) {
+      return {
+        ok: false,
+        error: `El ejercicio #${index + 1} tiene "repetitionsCount" inválido. Debe ser un número entero positivo.`,
+      };
+    }
+    exercise.repetitionsCount = repetitionsCount;
+  }
+
+  return { ok: true, workout: exercise };
+};
+
+export const validateWorkout = (input: unknown): WorkoutValidationResult => {
+  if (typeof input !== "object" || input === null) {
+    return { ok: false, error: "El JSON debe representar un objeto." };
+  }
+
+  const record = input as Record<string, unknown>;
+  const { id, name, dificultyLevel, exercises } = record;
+
+  if (!isNonEmptyString(id)) {
+    return { ok: false, error: 'El campo "id" debe ser un string no vacío.' };
+  }
+
+  if (!isNonEmptyString(name)) {
+    return { ok: false, error: 'El campo "name" debe ser un string no vacío.' };
+  }
+
+  if (typeof dificultyLevel !== "number" || !allowedLevels.has(dificultyLevel)) {
+    return {
+      ok: false,
+      error: 'El campo "dificultyLevel" debe ser un número entero entre 1 y 5.',
+    };
+  }
+
+  if (!Array.isArray(exercises) || exercises.length === 0) {
+    return {
+      ok: false,
+      error: 'El campo "exercises" debe ser un array con al menos un ejercicio.',
+    };
+  }
+
+  const normalizedExercises: Exercise[] = [];
+  for (let i = 0; i < exercises.length; i += 1) {
+    const result = sanitizeExercise(exercises[i], i);
+    if (!result.ok) {
+      return result;
+    }
+    normalizedExercises.push(result.workout);
+  }
+
+  const workout: Workout = {
+    id: (id as string).trim(),
+    name: (name as string).trim(),
+    dificultyLevel: dificultyLevel as Workout["dificultyLevel"],
+    exercises: normalizedExercises,
+  };
+
+  return { ok: true, workout };
+};
+
+export const parseWorkoutJson = (text: string): WorkoutValidationResult => {
+  try {
+    const data = JSON.parse(text);
+    return validateWorkout(data);
+  } catch {
+    return { ok: false, error: "El texto no es un JSON válido." };
+  }
+};


### PR DESCRIPTION
## Summary
- read workouts from localStorage and persist changes while exposing add/remove actions in the store
- validate workout payloads to ensure they match the required interface
- add UI to import workouts from JSON text and delete saved workouts with confirmation

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9aa37963883229dd2bcfea4bed9cf