### PR TITLE
Configure GitHub Pages base path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,69 +4,74 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    tailwindcss(),
-    react(),
-    VitePWA({
-      registerType: "autoUpdate",
-      injectRegister: "auto",
-      useCredentials: true,
+export default defineConfig(({ command }) => {
+  const base = command === "build" ? "/pwa-workouts/" : "/";
 
-      pwaAssets: {
-        disabled: false,
-        config: true,
-      },
+  return {
+    base,
+    plugins: [
+      tailwindcss(),
+      react(),
+      VitePWA({
+        registerType: "autoUpdate",
+        injectRegister: "auto",
+        useCredentials: true,
 
-      manifest: {
-        name: "Workouts",
-        short_name: "Workouts",
-        description: "Todos tus entrenamientos en un solo lugar",
-        theme_color: "#ffffff",
-        background_color: "#ffffff",
-        display: "standalone",
-        start_url: "/",
-        scope: "/",
-        icons: [
-          { src: "pwa-192x192.png", sizes: "192x192", type: "image/png" },
-          { src: "pwa-512x512.png", sizes: "512x512", type: "image/png" },
-          {
-            src: "maskable-icon-512x512.png",
-            sizes: "512x512",
-            type: "image/png",
-            purpose: "any maskable",
-          },
-        ],
-      },
+        pwaAssets: {
+          disabled: false,
+          config: true,
+        },
 
-      workbox: {
-        globPatterns: ["**/*.{js,css,html,svg,png,ico,webp,woff2}"],
-        cleanupOutdatedCaches: true,
-        clientsClaim: true,
-        navigateFallback: "/index.html",
-        runtimeCaching: [
-          {
-            urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
-            handler: "StaleWhileRevalidate",
-            options: { cacheName: "google-fonts-styles" },
-          },
-          {
-            urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
-            handler: "CacheFirst",
-            options: {
-              cacheName: "google-fonts-webfonts",
-              expiration: { maxEntries: 30, maxAgeSeconds: 60 * 60 * 24 * 365 },
+        manifest: {
+          name: "Workouts",
+          short_name: "Workouts",
+          description: "Todos tus entrenamientos en un solo lugar",
+          theme_color: "#ffffff",
+          background_color: "#ffffff",
+          display: "standalone",
+          start_url: base,
+          scope: base,
+          icons: [
+            { src: "pwa-192x192.png", sizes: "192x192", type: "image/png" },
+            { src: "pwa-512x512.png", sizes: "512x512", type: "image/png" },
+            {
+              src: "maskable-icon-512x512.png",
+              sizes: "512x512",
+              type: "image/png",
+              purpose: "any maskable",
             },
-          },
-        ],
-      },
+          ],
+        },
 
-      devOptions: {
-        enabled: false,
-        navigateFallback: "index.html",
-        suppressWarnings: true,
-        type: "module",
-      },
-    }),
-  ],
+        workbox: {
+          globPatterns: ["**/*.{js,css,html,svg,png,ico,webp,woff2}"],
+          cleanupOutdatedCaches: true,
+          clientsClaim: true,
+          navigateFallback: `${base}index.html`,
+          runtimeCaching: [
+            {
+              urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
+              handler: "StaleWhileRevalidate",
+              options: { cacheName: "google-fonts-styles" },
+            },
+            {
+              urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
+              handler: "CacheFirst",
+              options: {
+                cacheName: "google-fonts-webfonts",
+                expiration: { maxEntries: 30, maxAgeSeconds: 60 * 60 * 24 * 365 },
+              },
+            },
+          ],
+        },
+
+        devOptions: {
+          enabled: false,
+          navigateFallback: "index.html",
+          suppressWarnings: true,
+          type: "module",
+        },
+      }),
+    ],
+  };
 });


### PR DESCRIPTION
## Summary
- adjust Vite configuration to set the base path when building for GitHub Pages
- align PWA manifest, Workbox fallback, and asset handling with the dynamic base path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb23fae298832298e59de4e32b61f4